### PR TITLE
Fix `DenoKvLeaderboardClient` remove atomic operation

### DIFF
--- a/lib/leaderboard/denokv/denokv_leaderboard_client.ts
+++ b/lib/leaderboard/denokv/denokv_leaderboard_client.ts
@@ -71,17 +71,11 @@ export class DenoKvLeaderboardClient implements leaderboard.LeaderboardClient {
       throw new Error("Failed to update season");
     }
 
-    // Update the season ID.
-    const updateSeasonIDOp = this.kv.atomic();
-    if (prevSeasonResult) {
-      updateSeasonIDOp.check(prevSeasonResult);
-    }
-
     // Update the current season ID.
-    const updateSeasonIDResult = await updateSeasonIDOp.set(
+    const updateSeasonIDResult = await this.kv.set(
       [LeaderboardKvPrefix.SEASON_ID],
       season.id,
-    ).commit();
+    );
     if (!updateSeasonIDResult.ok) {
       throw new Error("Failed to update season ID");
     }


### PR DESCRIPTION
### Changes

- Removes atomic check from update season ID operation.

Resolves #27.