### PR TITLE
Add secret binding to `push`

### DIFF
--- a/cf/dailies/env.ts
+++ b/cf/dailies/env.ts
@@ -38,5 +38,7 @@ export async function push() {
   return await daily(
     "push",
     DENOFLARE_SCRIPT_NAME,
+    "--secret-binding",
+    `WEBHOOK_URL:${WEBHOOK_URL}`,
   );
 }


### PR DESCRIPTION
### Changes

Add secret binding to `cf/dailies/env.ts`'s `push`, matching `serve`'s secret binding.

### Reasoning

Apparently, secrets are reset on each push to Cloudflare unless bound to the procedure on every deployment.

Resolves #29.