### PR TITLE
Fix LC user verification

### DIFF
--- a/lib/lc/client.ts
+++ b/lib/lc/client.ts
@@ -18,7 +18,10 @@ export class LCClient implements LCClientInterface {
    * verifyUser verifies the user by username.
    */
   public async verifyUser(username: string): Promise<boolean> {
-    const response = await this.fetch(`https://leetcode.com/${username}/`);
+    const response = await this.fetch(
+      `https://leetcode.com/${username}/`,
+      { headers: { "priority": "u=0, i" } },
+    );
     return response.status === 200;
   }
 


### PR DESCRIPTION
For some reason, this request spontaneously required the headers `{ "priority": "u=0, i" }`. I figured this out by copying the fetch from the navigation tab and removing all of the options that aren't necessary.

Fixes #59.