### PR TITLE
Change daily colors

### DIFF
--- a/lib/api/dailies.ts
+++ b/lib/api/dailies.ts
@@ -143,15 +143,15 @@ export function makeDailyWebhookEmbeds(
 export function getColorByDifficulty(difficulty: string): number | undefined {
   switch (difficulty) {
     case "Easy": {
-      return 0x339933;
+      return 0x46c6c2;
     }
 
     case "Medium": {
-      return 0xff6600;
+      return 0xfac31d;
     }
 
     case "Hard": {
-      return 0xe91e63;
+      return 0xf8615c;
     }
   }
 }

--- a/lib/leaderboard/scores.ts
+++ b/lib/leaderboard/scores.ts
@@ -264,7 +264,7 @@ export function formatDifficulty(difficulty?: string): string {
     }
 
     case "Medium": {
-      return "🟧";
+      return "🟨";
     }
 
     case "Hard": {


### PR DESCRIPTION
Change the Discord embed and leaderboard colors to closely match the difficulty colors from LeetCode.

The new colors are as they appear in the difficulty label when opening a LeetCode problem (it is somehow different from what it shows in the problems list lol).